### PR TITLE
feature/GI-7: NIZK Proof of Knowledge of Discrete Log

### DIFF
--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,5 +1,6 @@
 <component name="InspectionProjectProfileManager">
   <settings>
+    <option name="PROJECT_PROFILE" value="Default" />
     <option name="USE_PROJECT_PROFILE" value="false" />
     <version value="1.0" />
   </settings>

--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ all liability related to its use.
 - **Non-interactive Zero-Knowledge** (NIZK) **Proofs of Knowledge** (PoKs) **of Discrete Logarithms** (over Elliptic
 Curves)
 - **NIZK Proofs of Knowledge** (PoKs) **of _Equal_ Discrete Logarithms**
-(based on [Chaum/Pedersen protocol](https://link.springer.com/content/pdf/10.1007/3-540-48071-4_7.pdf))
+(based on the [Chaum-Pedersen protocol](https://link.springer.com/content/pdf/10.1007/3-540-48071-4_7.pdf))
 
 #### Planned Future Work:
 - **Pedersen Commitments** & **Vector Pedersen Commitments** (on Elliptic Curves)
 - **Adaptor Signatures for ECC Schnorr** (single-party)
 - Support for **[BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) compatible ECC Schnorr 
-Signatures** (on the `secp256k1` elliptic curve used by Bitcoin)
+Signatures** (on the `secp256k1` elliptic curve used by Bitcoin & Ethereum)
 - **BIP-340 compatible Two-Party ECC Schnorr Signatures**
 - **Zero-Knowledge Range Proofs** (based on Bulletproofs)
 - **Two-Party ECDSA Signatures** (based on [Yehuda Lindell's protocol](https://eprint.iacr.org/2017/552.pdf))

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ all liability related to its use.
 ### Functional Existing Modules
 **NOTE:** R&D-only Status (see above disclaimer)
 
-- **Schnorr Signatures on Elliptic Curves** (`scriptless_zkp.ecc.schnorr`)
+- **Schnorr Signatures on Elliptic Curves** [`scriptless_zkp.ecc.schnorr`]
   - Currently supported (Weierstrass) prime-order curves:
     - **NIST P-256** (`secp256r1`)
   - TODO: Planned support for (Weierstrass) prime-order curves:
@@ -23,7 +23,9 @@ all liability related to its use.
     - NIST P-521 (`secp521r1`)
   - TODO: Planned support for curve(s), pending support in a backing dependency:
     - `secp256k1` (used for ECDSA on Bitcoin & Ethereum blockchains)
-- **HMAC-based & Blake2b-based Keyed Hash Cryptographic Commitments** (`scriptless_zkp.commitments.hmac_commitments`)
+- **HMAC-based & Blake2b-based Keyed Hash Cryptographic Commitments** [`scriptless_zkp.commitments.hmac_commitments`]
+- **Non-interactive Zero-Knowledge** (NIZK) **Proofs of Knowledge** (PoKs) **of Discrete Logarithms** (over Elliptic
+Curves) [`scriptless_zkp.ecc.zkp`]
 
 ### Planned Future Work & Coming Soon
 
@@ -32,8 +34,8 @@ all liability related to its use.
 - **Two-Party ECC Schnorr Signatures**
   - Including distributed multi-party computation of joint public key & private key-shares, and ZKP-based
   detection of deviations from correct protocol operation by either party.
-- **Non-interactive Zero-Knowledge** (NIZK) **Proofs of Knowledge** (PoKs) **of Discrete Logarithms** (over Elliptic
-Curves)
+- ~~Non-interactive Zero-Knowledge (NIZK) Proofs of Knowledge (PoKs) of Discrete Logarithms (over Elliptic
+Curves)~~
 - **NIZK Proofs of Knowledge** (PoKs) **of _Equal_ Discrete Logarithms**
 (based on the [Chaum-Pedersen protocol](https://link.springer.com/content/pdf/10.1007/3-540-48071-4_7.pdf))
 

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,0 +1,29 @@
+#-------------------------------------------------------------------------------#
+#               Qodana analysis is configured by qodana.yaml file               #
+#             https://www.jetbrains.com/help/qodana/qodana-yaml.html            #
+#-------------------------------------------------------------------------------#
+version: "1.0"
+
+#Specify inspection profile for code analysis
+profile:
+  name: qodana.starter
+
+#Enable inspections
+#include:
+#  - name: <SomeEnabledInspectionId>
+
+#Disable inspections
+#exclude:
+#  - name: <SomeDisabledInspectionId>
+#    paths:
+#      - <path/where/not/run/inspection>
+
+#Execute shell command before Qodana execution (Applied in CI/CD pipeline)
+#bootstrap: sh ./prepare-qodana.sh
+
+#Install IDE plugins before Qodana execution (Applied in CI/CD pipeline)
+#plugins:
+#  - id: <plugin.id> #(plugin id can be found at https://plugins.jetbrains.com)
+
+#Specify Qodana linter for analysis (Applied in CI/CD pipeline)
+linter: jetbrains/qodana-python:latest

--- a/src/python/scriptless_zkp/ecc/zkp/nizk_dlog_proof.py
+++ b/src/python/scriptless_zkp/ecc/zkp/nizk_dlog_proof.py
@@ -1,0 +1,445 @@
+"""
+Provides a noninteractive zero-knowledge (NIZK) proof of knowledge of discrete logarithm,
+over a prime-order elliptic curve group (e.g., NIST P-256).
+"""
+from __future__ import annotations
+
+import base64
+import binascii
+
+from hashlib import sha512
+from typing import Optional, NewType
+
+from Cryptodome.PublicKey import ECC
+from Cryptodome.Util import number
+
+from scriptless_zkp import STRING_ENCODING_FIELD_DELIMITER
+from scriptless_zkp.ecc.ecc_utils import WeierstrassEllipticCurveConfig
+
+
+class NIZKDiscreteLogCommon:
+    """
+    This noninteractive protocol, for proving & verifying knowledge of a discrete logarithm, is based on Schnorr's
+    identification/authentication protocol, which has been transformed via the Fiat-Shamir transform.
+    """
+
+    def __init__(self, curve_config: WeierstrassEllipticCurveConfig):
+        self.curve_config: WeierstrassEllipticCurveConfig = curve_config
+        self.curve: str = self.curve_config.curve
+        self.order: int = self.curve_config.order
+        self.G: ECC.EccPoint = self.curve_config.base_point  # curve's generator
+
+    def calc_public_hash(
+            self,
+            dlog_reference_point: ECC.EccPoint,
+            ephemeral_public_key: ECC.EccKey,
+            dlog_base: Optional[ECC.EccPoint] = None
+    ) -> int:
+        """
+        Calculates a public hash (SHA-512) of the provided discrete log base, elliptic curve reference point & random
+        ephemeral public key (i.e., all public parameters). This hash replaces the verifier-provided random challenge,
+        of the base interactive zero-knowledge proof (sigma) protocol, in the noninteractive zero-knowledge (NIZK)
+        proof of knowledge of discrete logarithm.
+        """
+        dlog_base_as_pubkey: ECC.EccKey = ECC.construct(
+            curve=self.curve, point_x=self.G.x, point_y=self.G.y
+        ) if dlog_base is None else ECC.construct(
+            curve=self.curve, point_x=dlog_base.x, point_y=dlog_base.y
+        )
+
+        dlog_ref_point_as_pubkey: ECC.EccKey = ECC.construct(
+            curve=self.curve, point_x=dlog_reference_point.x, point_y=dlog_reference_point.y
+        )
+
+        md = sha512()
+        md.update(dlog_ref_point_as_pubkey.export_key(format='SEC1'))
+        md.update(dlog_base_as_pubkey.export_key(format='SEC1'))
+        md.update(ephemeral_public_key.export_key(format='SEC1'))
+        public_hash_bytes: bytes = md.digest()
+
+        return number.bytes_to_long(public_hash_bytes)
+
+
+class NIZKDiscreteLogParameters:
+    curve_config: WeierstrassEllipticCurveConfig
+    dlog_ref_point: ECC.EccPoint  # EC point = dlog * dlog_base
+    dlog_base: ECC.EccPoint
+
+    def __init__(
+            self,
+            curve_config: WeierstrassEllipticCurveConfig,
+            dlog_reference_point: ECC.EccPoint,
+            dlog_base: Optional[ECC.EccPoint] = None
+    ):
+        self.curve_config = curve_config
+        self.dlog_ref_point = dlog_reference_point
+        self.dlog_base = self.curve_config.base_point if dlog_base is None else dlog_base
+
+    @classmethod
+    def from_string_encoding(cls, encoded_dlog_proof_params: str) -> NIZKDiscreteLogParameters:
+        """
+        Factory function that constructs an NIZK proof of knowledge of discrete logarithm's associated parameters
+        (`NIZKDiscreteLogParameters`), including the elliptic curve's canonical name, discrete log (reference) point,
+        and discrete log base, via parsing of its string encoding:
+            `<elliptic-curve-name>:<dlog_ref_point_base64>:<dlog_base_base64>`
+        :param encoded_dlog_proof_params: a string-encoded `NIZKDiscreteLogParameters`, which uses base64-encoding for
+               binary fields and a colon field delimiter.
+        :return: an NIZK proof of knowledge of discrete logarithm's associated parameters via parsing of its string
+                 encoding.
+        """
+        EXPECTED_FIELDS_COUNT = 3
+
+        dlog_param_fields: list[str] = encoded_dlog_proof_params.split(STRING_ENCODING_FIELD_DELIMITER)
+        if len(dlog_param_fields) != EXPECTED_FIELDS_COUNT:
+            raise ValueError(
+                f"Unexpected number of fields [{len(dlog_param_fields)}] in string encoding of "
+                f"NIZKDiscreteLogParameters [expected_fields_count={EXPECTED_FIELDS_COUNT}]"
+            )
+
+        curve_name: str = dlog_param_fields[0]
+        curve_config: WeierstrassEllipticCurveConfig
+        match curve_name:
+            case str(curve) if WeierstrassEllipticCurveConfig.secp256r1().has_curve_name(curve):
+                curve_config = WeierstrassEllipticCurveConfig.secp256r1()
+            case unsupported:
+                raise ValueError(
+                    f"Unsupported ECC curve name in string encoding of {cls.__name__}: {unsupported!s}"
+                )
+
+        try:
+            dlog_ref_point: ECC.EccPoint = ECC.import_key(
+                base64.b64decode(dlog_param_fields[1], validate=True),
+                curve_name=curve_name
+            ).pointQ
+        except binascii.Error as bae:
+            raise ValueError(
+                f"Invalid base64-encoded ECC discrete log (reference) point in string encoding of {cls.__name__} "
+                f"-- caused by: {bae}"
+            ) from bae  # include base64 decoding exception cause
+        except ValueError as ve:
+            raise ValueError(
+                f"Invalid 'SEC1' public key-encoded ECC discrete log (reference) point, in string encoding of "
+                f"{cls.__name__} -- caused by: {ve}"
+            ) from ve  # include 'SEC1' public key decoding exception cause
+
+        try:
+            dlog_base: ECC.EccPoint = ECC.import_key(
+                base64.b64decode(dlog_param_fields[2], validate=True),
+                curve_name=curve_name
+            ).pointQ
+        except binascii.Error as bae:
+            raise ValueError(
+                f"Invalid base64-encoded ECC discrete log base point in string encoding of {cls.__name__} "
+                f"-- caused by: {bae}"
+            ) from bae  # include base64 decoding exception cause
+        except ValueError as ve:
+            raise ValueError(
+                f"Invalid 'SEC1' public key-encoded ECC discrete log base point, in string encoding of "
+                f"{cls.__name__} -- caused by: {ve}"
+            ) from ve  # include 'SEC1' public key decoding exception cause
+
+        return cls(curve_config, dlog_ref_point, dlog_base)
+
+    def encode_parameters(self) -> bytes:
+        # Convert EC reference point (ECC.EccPoint) to public key (ECC.EccKey), then encode as bytes in 'SEC1' encoding.
+        dlog_ref_point_encoded: bytes = ECC.construct(
+            curve=self.curve_config.curve,
+            point_x=self.dlog_ref_point.x,
+            point_y=self.dlog_ref_point.y
+        ).export_key(format='SEC1')
+
+        # Convert EC dlog base point (ECC.EccPoint) to public key (ECC.EccKey), then encode as bytes in 'SEC1' encoding.
+        dlog_base_encoded: bytes = ECC.construct(
+            curve=self.curve_config.curve,
+            point_x=self.dlog_base.x,
+            point_y=self.dlog_base.y
+        ).export_key(format='SEC1')
+
+        # Return the concatenation of the 'SEC1'-encoded EC ref. point & dlog base point.
+        return dlog_ref_point_encoded + dlog_base_encoded
+
+    def encode_as_string(self) -> str:
+        """
+        Returns a string encoding of this NIZK proof's associated parameters, including the elliptic curve's canonical
+        name, discrete log (reference) point & discrete log base.
+        The encoding uses base64 for binary values and is colon-delimited as follows:
+            `<elliptic-curve-name>:<dlog_ref_point_base64>:<dlog_base_base64>`
+        :return: a string encoding of this NIZK proof's associated parameters, which uses base64-encoding for binary
+                 fields and colon delimited fields.
+        """
+        # Convert EC reference point (ECC.EccPoint) to public key (ECC.EccKey), then encode as bytes in 'SEC1' encoding.
+        dlog_ref_point_encoded: bytes = ECC.construct(
+            curve=self.curve_config.curve,
+            point_x=self.dlog_ref_point.x,
+            point_y=self.dlog_ref_point.y
+        ).export_key(format='SEC1')
+        dlog_ref_point_base64: str = base64.b64encode(dlog_ref_point_encoded).decode('utf-8')
+
+        # Convert EC dlog base point (ECC.EccPoint) to public key (ECC.EccKey), then encode as bytes in 'SEC1' encoding.
+        dlog_base_encoded: bytes = ECC.construct(
+            curve=self.curve_config.curve,
+            point_x=self.dlog_base.x,
+            point_y=self.dlog_base.y
+        ).export_key(format='SEC1')
+        dlog_base_base64: str = base64.b64encode(dlog_base_encoded).decode('utf-8')
+
+        return ':'.join([self.curve_config.curve, dlog_ref_point_base64, dlog_base_base64])
+
+
+"""
+Efficient type for an NIZK proof of knowledge of discrete log's signature that auto-casts to an `int`, but not from
+an `int`, providing type safety in function & method calls.
+"""
+DiscreteLogProofSignature = NewType('NIZKDiscreteLogProofSignature', int)
+
+
+class NIZKDiscreteLogProof:
+    discrete_log_params: NIZKDiscreteLogParameters
+    ephemeral_public_key: ECC.EccKey
+    proof_signature: DiscreteLogProofSignature
+
+    def __init__(
+            self,
+            discrete_log_params: NIZKDiscreteLogParameters,
+            ephemeral_public_key: ECC.EccKey,
+            proof_signature: DiscreteLogProofSignature
+    ):
+        self.curve_config = discrete_log_params.curve_config
+        self.discrete_log_params = discrete_log_params
+        self.ephemeral_public_key = ephemeral_public_key
+        self.proof_signature = proof_signature
+
+    @classmethod
+    def from_string_encoding(cls, encoded_dlog_proof: str) -> NIZKDiscreteLogProof:
+        """
+        Factory function that constructs an `NIZKDiscreteLogProof` via parsing of its string encoding as follows:
+            `<elliptic-curve-name>:<dlog_ref_point_base64>:<dlog_base_base64>:<proof_signature_base64>
+                :<proof_verification_key_base64>`
+        :param encoded_dlog_proof: a string-encoded `NIZKDiscreteLogProof`, which uses base64-encoding for binary
+               fields and a colon field delimiter.
+        :return: an `NIZKDiscreteLogProof` via parsing of its string encoding.
+        """
+        EXPECTED_FIELDS_COUNT = 5
+
+        dlog_proof_fields: list[str] = encoded_dlog_proof.split(STRING_ENCODING_FIELD_DELIMITER)
+        if len(dlog_proof_fields) != EXPECTED_FIELDS_COUNT:
+            raise ValueError(
+                f"Unexpected number of fields [{len(dlog_proof_fields)}] in string encoding of {cls.__name__} "
+                f"[expected_fields_count={EXPECTED_FIELDS_COUNT}]"
+            )
+
+        try:
+            encoded_dlog_params: str = ':'.join(dlog_proof_fields[0:3])
+            discrete_log_params: NIZKDiscreteLogParameters = NIZKDiscreteLogParameters.from_string_encoding(
+                encoded_dlog_params  # fields #0-2 comprise the NIZK proof's assoc. parameters
+            )
+        except ValueError as ve:
+            raise ValueError(
+                f"Missing or invalid NIZK discrete log proof parameters in string encoding of {cls.__name__} "
+                f"-- caused by: {ve}"
+            ) from ve
+
+        try:
+            proof_signature: DiscreteLogProofSignature = DiscreteLogProofSignature(number.bytes_to_long(
+                base64.b64decode(dlog_proof_fields[3], validate=True)
+            ))
+        except binascii.Error as bae:
+            raise ValueError(
+                f"Invalid base64-encoded NIZK discrete log proof signature in string encoding of {cls.__name__} "
+                f"-- caused by: {bae}"
+            ) from bae  # include base64 decoding exception cause
+        except ValueError as ve:
+            raise ValueError(
+                f"Invalid NIZK discrete log proof signature in string encoding of {cls.__name__} -- caused by: {ve}"
+            ) from ve  # include bytes-to-long decoding exception cause
+
+        try:
+            proof_verification_key: ECC.EccKey = ECC.import_key(
+                base64.b64decode(dlog_proof_fields[4], validate=True),
+                curve_name=discrete_log_params.curve_config.curve
+            )
+        except binascii.Error as bae:
+            raise ValueError(
+                f"Invalid base64-encoded proof verification key in string encoding of {cls.__name__} "
+                f"-- caused by: {bae}"
+            ) from bae  # include base64 decoding exception cause
+        except ValueError as ve:
+            raise ValueError(
+                f"Invalid 'SEC1'-encoded proof verification ECC public key in string encoding of {cls.__name__} "
+                f"-- caused by: {ve}"
+            ) from ve  # include 'SEC1' public key decoding exception cause
+
+        return cls(
+            discrete_log_params,
+            proof_verification_key,
+            proof_signature
+        )
+
+    @property
+    def dlog_reference_point(self) -> ECC.EccPoint:
+        """
+        Returns the elliptic curve (reference) point `Q` (i.e., `Q = dlog * dlog_base`), for which knowledge of its
+        discrete logarithm `dlog` w.r.t. base `dlog_base` is being proven.
+        :return: the elliptic curve (reference) point, for which knowledge of its discrete logarithm is being proven.
+        """
+        return self.discrete_log_params.dlog_ref_point
+
+    @property
+    def dlog_base_point(self) -> ECC.EccPoint:
+        """
+        Returns the base `dlog_base` of the discrete logarithm, for which knowledge is being proven (i.e., where `dlog`
+        is the discrete logarithm of `Q` in: `Q = dlog * dlog_base`).
+        :return: the base of the discrete logarithm, for which knowledge is being proven.
+        """
+        return self.discrete_log_params.dlog_base
+
+    def encode_for_commitment(self) -> bytes:
+        """
+        Binary encodes & concatenates this NIZK proof of knowledge of discrete logarithm, along with its associated
+        discrete log parameters, and proof verification key, as follows:
+            `<dlog_ref_point><dlog_base><proof_signature><proof_verification_key>`
+        Elliptic curve points are 'SEC1'-encoded.
+        :return: this NIZK proof of knowledge of discrete logarithm, along with its associated discrete log parameters,
+                 and proof verification key, binary encoded & concatenated, where 'SEC1' encoding is used for elliptic
+                 curve points.
+        """
+        # Encode values that will be committed to:
+        encoded_dlog_params: bytes = self.discrete_log_params.encode_parameters()
+        encoded_proof_verification_key: bytes = self.ephemeral_public_key.export_key(format='SEC1')
+        encoded_dlog_proof_signature: bytes = number.long_to_bytes(self.proof_signature)
+
+        # Concatenate encoded commitment values.
+        return encoded_dlog_params + encoded_proof_verification_key + encoded_dlog_proof_signature
+
+    def encode_as_string(self) -> str:
+        """
+        Encodes this NIZK proof of knowledge of discrete logarithm, along with its associated discrete log parameters,
+        and proof verification key, as a colon-delimited string of base64-encoded values, as follows:
+            `<elliptic-curve-name>:<dlog_ref_point_base64>:<dlog_base_base64>:<proof_signature_base64>
+                :<proof_verification_key_base64>`
+        where `dlog_ref_point = dlog_base * dlog` and `dlog_base` and `dlog_ref_point` are both elliptic curve points.
+        Elliptic curve points are 'SEC1'-encoded prior to base64 encoding.
+        :return: this NIZK proof of knowledge of discrete logarithm, along with its associated discrete log parameters,
+                 and proof verification key, encoded as a colon-delimited string of base64-encoded values.
+        """
+        # Encode values that will be committed to:
+        encoded_dlog_params: str = self.discrete_log_params.encode_as_string()
+
+        encoded_dlog_proof_signature: bytes = number.long_to_bytes(self.proof_signature)
+        dlog_proof_signature_base64: str = base64.b64encode(encoded_dlog_proof_signature).decode('utf-8')
+
+        encoded_proof_verification_key: bytes = self.ephemeral_public_key.export_key(format='SEC1')
+        proof_verification_key_base64: str = base64.b64encode(encoded_proof_verification_key).decode('utf-8')
+
+        return ':'.join([encoded_dlog_params, dlog_proof_signature_base64, proof_verification_key_base64])
+
+
+class NIZKDiscreteLogProver:
+    """Supports constructing NIZK proofs of knowledge of discrete logarithm, for points on the given elliptic curve."""
+
+    def __init__(self, curve_config: WeierstrassEllipticCurveConfig):
+        self.curve_config = curve_config
+        self.curve = self.curve_config.curve
+        self.order = self.curve_config.order
+        self.G: ECC.EccPoint = self.curve_config.base_point  # curve's generator
+        self.common = NIZKDiscreteLogCommon(self.curve_config)
+
+    def calc_proof(
+            self,
+            discrete_log: int,
+            dlog_reference_point: Optional[ECC.EccPoint] = None,
+            discrete_log_base: Optional[ECC.EccPoint] = None
+    ) -> NIZKDiscreteLogProof:
+        """
+        Calculates a noninteractive zero-knowledge (NIZK) proof of knowledge of discrete logarithm, for the given
+        ECC discrete logarithm and associated discrete log base.
+        :param discrete_log: ECC discrete logarithm for which to produce an NIZK proof of knowledge.
+        :param dlog_reference_point: ECC point for which knowledge of its discrete log is being proven for the given
+               base point (i.e., "dlog_ref_pt = dlog * dlog_base").
+        :param discrete_log_base: ECC discrete logarithm base corresponding to the provided discrete log, for which an
+               NIZK proof of knowledge is to be produced.
+        :return: a proof of knowledge of ECC discrete logarithm to the provided discrete log base, as a tuple:
+                 (ephemeral_pub_key, signature).
+        """
+        # Generate a random ephemeral ECC key-pair.
+        ephemeral_keypair: ECC.EccKey = self._generate_ephemeral_keypair()
+        ephemeral_private_key: int = int(ephemeral_keypair.d)
+        ephemeral_public_key: ECC.EccKey = ephemeral_keypair.public_key()
+
+        if dlog_reference_point is None:
+            # Produce the EC reference point, for which its discrete logarithm is being proven, if not provided.
+            dlog_ref_point: ECC.EccPoint = self._calc_dlog_reference_point(discrete_log, discrete_log_base)
+        else:
+            dlog_ref_point: ECC.EccPoint = dlog_reference_point
+
+        # Calc. public hash (SHA-512) of the dlog_ref_point, ephemeral pub. key & dlog_base, which replaces an
+        # interactive ZKP's verifier-provided random challenge.
+        public_hash: int = self.common.calc_public_hash(dlog_ref_point, ephemeral_public_key, discrete_log_base)
+
+        # Calculate proof signature: sig := ephemeral_priv - pub_hash*dlog (mod o(G))
+        proof_signature: int = (ephemeral_private_key - public_hash * discrete_log) % self.order
+
+        return NIZKDiscreteLogProof(
+            NIZKDiscreteLogParameters(self.curve_config, dlog_ref_point, discrete_log_base),
+            ephemeral_public_key,
+            DiscreteLogProofSignature(proof_signature)
+        )
+
+    def _generate_ephemeral_keypair(self) -> ECC.EccKey:
+        """Generates a random ephemeral ECC key-pair."""
+        return ECC.generate(curve=self.curve)
+
+    def _calc_dlog_reference_point(
+            self,
+            discrete_log: int,
+            discrete_log_base: Optional[ECC.EccPoint] = None
+    ) -> ECC.EccPoint:
+        """
+        Calculates the elliptic curve (reference) point, for which knowledge of the provided discrete logarithm to the
+        given base will be proven by this `NIZKDiscreteLogProver`.
+        :param discrete_log discrete logarithm from which to produce the elliptic curve (reference) point `Q`
+               (i.e., as `Q = dlog * dlog_base`).
+        :param discrete_log_base discrete logarithm base corresponding to the provided discrete log, for which the
+               elliptic curve (reference) point is being produced; defaulting to the elliptic curve's base point if not
+               provided.
+        :return the public elliptic curve (reference) point, for which knowledge of the provided discrete logarithm to
+                the given base will be proven.
+        """
+        # Default to the curve's base point as discrete logarithm base, if not provided.
+        if discrete_log_base is None:
+            return self.G * discrete_log
+        else:
+            return discrete_log_base * discrete_log
+
+
+class NIZKDiscreteLogVerifier:
+    """Supports verifying NIZK proofs of knowledge of discrete logarithm, for points on the given elliptic curve."""
+
+    def __init__(self, curve_config: WeierstrassEllipticCurveConfig):
+        self.curve_config = curve_config
+        self.common = NIZKDiscreteLogCommon(self.curve_config)
+
+    def verify_proof(self, discrete_log_proof: NIZKDiscreteLogProof) -> bool:
+        """
+        Verifies a noninteractive zero-knowledge (NIZK) proof of knowledge of discrete logarithm.
+        :param discrete_log_proof: NIZK proof of knowledge of discrete logarithm to be verified.
+        :return: whether the provided NIZK proof of knowledge of discrete logarithm is valid.
+        """
+        dlog_base: ECC.EccPoint = discrete_log_proof.dlog_base_point
+        dlog_ref_point: ECC.EccPoint = discrete_log_proof.dlog_reference_point
+
+        # Calc. public hash (SHA-512) of the dlog_ref_point, ephemeral pub. key & dlog_base
+        public_hash: int = self.common.calc_public_hash(
+            dlog_ref_point,
+            discrete_log_proof.ephemeral_public_key,
+            dlog_base
+        )
+        # Recalculate the proof's ephemeral public key via the proof's signature & public hash, and its associated
+        # discrete log reference point (incl. the discrete log base):
+        #     `verification_key ?= (dlog_base * proof_sig) + (ref_point * pub_hash)`
+        ephemeral_verification: ECC.EccPoint = (
+            dlog_base * discrete_log_proof.proof_signature
+        ) + (dlog_ref_point * public_hash)
+
+        # Proof is valid if the recalculated ephemeral public key matches the proof's provided ephemeral public key.
+        return ephemeral_verification == discrete_log_proof.ephemeral_public_key.pointQ

--- a/src/python/scriptless_zkp/ecc/zkp/nizk_dlog_proof_commitments.py
+++ b/src/python/scriptless_zkp/ecc/zkp/nizk_dlog_proof_commitments.py
@@ -1,0 +1,310 @@
+"""
+Provides provers & verifiers for non-interactive zero-knowledge (NIZK) proofs of knowledge
+of discrete logarithms, along with cryptographic commitments to associated parameters, such
+as the discrete logarithm's base and the value (e.g., elliptic curve point) for which
+knowledge of its discrete log is being proven.
+"""
+from __future__ import annotations
+
+import base64
+import binascii
+import uuid
+
+from typing import Literal, Optional
+
+from scriptless_zkp import PartyId, STRING_ENCODING_FIELD_DELIMITER
+from scriptless_zkp.commitments.hmac_commitments import (
+    KeyedHashCommitment, KeyedHashCommitmentUtils, RevealedKeyedHashCommitment
+)
+from scriptless_zkp.ecc.ecc_utils import WeierstrassEllipticCurveConfig
+from scriptless_zkp.ecc.zkp.nizk_dlog_proof import (
+    NIZKDiscreteLogProof, NIZKDiscreteLogProver, NIZKDiscreteLogVerifier, NIZKDiscreteLogParameters
+)
+
+
+class SealedDiscreteLogProofCommitment:
+    session_id: uuid.UUID    # globally-unique ID for a protocol session
+    party_id: PartyId  # proving/committing party's ID (i.e., either #1: initiator or #2: responder)
+    commitment: KeyedHashCommitment
+
+    def __init__(
+            self,
+            party_id: int,
+            commitment: KeyedHashCommitment,
+            session_id: Optional[uuid.UUID] = None
+    ):
+        self.session_id = session_id if session_id is not None else uuid.uuid4()  # generate random UUID if not provided
+        self.party_id = type(self)._validate_party_id(party_id)
+        self.commitment = commitment
+
+    @classmethod
+    def for_dlog_proof(
+            cls,
+            party_id: PartyId,
+            dlog_proof: NIZKDiscreteLogProof,
+            hash_algorithm: str = KeyedHashCommitmentUtils.DEFAULT_HASH_ALGORITHM
+    ) -> (SealedDiscreteLogProofCommitment, bytearray):
+        """
+        Constructs a sealed commitment to the provided discrete logarithm proof and associated discrete log parameters,
+        including the discrete log reference point, discrete log base, proof signature & proof verification key.
+        The sealed commitment is returned, as well as the commitment verification key (to be revealed later).
+        :param party_id: prover/committer party's ID (i.e., either #1: initiator or #2: responder).
+        :param dlog_proof: noninteractive zero-knowledge (NIZK) proof of knowledge of discrete logarithm, to which to
+               commit.
+        :param hash_algorithm: cryptographic hash algorithm to be used for the keyed-hash commitment.
+        :return: a sealed commitment to the provided discrete logarithm proof and associated discrete log parameters,
+                 in addition to the commitment verification key (to be revealed later).
+        """
+        # Encode & concatenate the dlog parameters, dlog proof & verification key, to which we're committing.
+        encoded_commitment_values: bytes = dlog_proof.encode_for_commitment()
+
+        sealed_commitment: KeyedHashCommitment
+        revealed_commitment: RevealedKeyedHashCommitment
+        sealed_commitment, revealed_commitment = KeyedHashCommitmentUtils(
+            hash_algorithm
+        ).commit(encoded_commitment_values)
+
+        return cls(party_id, sealed_commitment), revealed_commitment.verification_key
+
+    @classmethod
+    def from_string_encoding(cls, encoded_sealed_commitment: str) -> SealedDiscreteLogProofCommitment:
+        """
+        Constructs a `SealedDiscreteLogProofCommitment` by parsing the provided string encoding (e.g., received via a
+        network transmission).
+        :param encoded_sealed_commitment: string encoding of a sealed discrete log proof commitment.
+        :return: a `SealedDiscreteLogProofCommitment` constructed from the provided string encoding.
+        """
+        EXPECTED_FIELDS_COUNT: int = 4
+        sealed_commitment_fields: list[str] = encoded_sealed_commitment.split(STRING_ENCODING_FIELD_DELIMITER)
+        if len(sealed_commitment_fields) != EXPECTED_FIELDS_COUNT:
+            raise ValueError(
+                f"Expected [{EXPECTED_FIELDS_COUNT}] fields in sealed discrete log proof commitment's string encoding, "
+                f"but found [{len(sealed_commitment_fields)}] fields."
+            )
+
+        try:
+            session_id: uuid.UUID = uuid.UUID(sealed_commitment_fields[0])
+        except ValueError as ve:
+            raise ValueError(
+                f"Failed to parse (UUID) session ID from string encoding of sealed discrete log proof commitment: "
+                f"{ve}"
+            ) from ve
+
+        try:
+            party_id: PartyId = cls._validate_party_id(
+                int(sealed_commitment_fields[1])
+            )
+        except ValueError as ve:
+            raise ValueError(
+                f"Failed to parse (int) party ID from string encoding of sealed discrete log proof commitment: {ve}"
+            ) from ve
+
+        try:
+            commitment: KeyedHashCommitment = KeyedHashCommitment.from_string_encoding(
+                STRING_ENCODING_FIELD_DELIMITER.join(sealed_commitment_fields[2:])
+            )
+        except ValueError as ve:
+            raise ValueError(
+                f"Failed to parse keyed-hash commitment from string encoding of sealed discrete log proof commitment: "
+                f"{ve}"
+            ) from ve
+
+        return cls(party_id, commitment, session_id)
+
+    def encode_as_string(self) -> str:
+        """
+        Encodes this sealed discrete log proof commitment as a string (e.g., for network transmission).
+        :return: string encoding of this sealed discrete log proof commitment.
+        """
+        return STRING_ENCODING_FIELD_DELIMITER.join([
+            str(self.session_id),
+            str(self.party_id),
+            self.commitment.encode_as_string()
+        ])
+
+    def reveal(
+            self,
+            dlog_proof: NIZKDiscreteLogProof,
+            commitment_verification_key: bytearray  # ephemeral commitment key
+    ) -> RevealedDiscreteLogProofCommitment:
+        return RevealedDiscreteLogProofCommitment.for_committed_proof(
+            self,
+            dlog_proof,
+            commitment_verification_key
+        )
+
+    @classmethod
+    def _validate_party_id(cls, party_id: int) -> PartyId:
+        match party_id:
+            case 1: return 1
+            case 2: return 2
+            case invalid:
+                raise ValueError(
+                    f"Invalid party ID provided when constructing a {cls.__name__}: {invalid}"
+                )
+
+
+class RevealedDiscreteLogProofCommitment:
+    session_id: uuid.UUID    # globally-unique ID for a protocol session
+    party_id: Literal[1, 2]  # prover/committer party's ID (i.e., either #1: initiator or #2: responder)
+    committed_dlog_proof: NIZKDiscreteLogProof
+    commitment_verification_key: bytearray
+    hash_algo: str
+
+    def __init__(
+            self,
+            session_id: uuid.UUID,
+            party_id: int,
+            discrete_log_proof: NIZKDiscreteLogProof,
+            commitment_verification_key: bytearray,
+            commitment_hash_algorithm: str
+    ):
+        self.party_id = type(self)._validate_party_id(party_id)
+        self.session_id = session_id
+        self.committed_dlog_proof = discrete_log_proof
+        self.commitment_verification_key = commitment_verification_key
+        self.hash_algo = commitment_hash_algorithm
+
+    @classmethod
+    def for_committed_proof(
+            cls,
+            sealed_proof_commitment: SealedDiscreteLogProofCommitment,
+            dlog_proof: NIZKDiscreteLogProof,
+            ephemeral_commitment_key: bytearray
+    ) -> RevealedDiscreteLogProofCommitment:
+        return cls(
+            sealed_proof_commitment.session_id,
+            sealed_proof_commitment.party_id,
+            dlog_proof,
+            ephemeral_commitment_key,
+            sealed_proof_commitment.commitment.hash_algorithm
+        )
+
+    @classmethod
+    def from_string_encoding(cls, encoded_revealed_commitment: str) -> RevealedDiscreteLogProofCommitment:
+        """
+        Factory function that parses the string encoding of a `RevealedDiscreteLogProofCommitment` (e.g., received via
+        network transmission).
+        :param encoded_revealed_commitment: string encoding of a `RevealedDiscreteLogProofCommitment` to be parsed.
+        :return: a new `RevealedDiscreteLogProofCommitment` constructed via parsing of its string encoding.
+        """
+        # noinspection PyPep8Naming
+        EXPECTED_FIELDS_COUNT = 9
+
+        revealed_commitment_fields: list[str] = encoded_revealed_commitment.split(STRING_ENCODING_FIELD_DELIMITER)
+        if len(revealed_commitment_fields) != EXPECTED_FIELDS_COUNT:
+            raise ValueError(
+                f"Unexpected number of fields [{len(revealed_commitment_fields)}] in string encoding of "
+                f"RevealedDiscreteLogProofCommitment [expected_fields_count={EXPECTED_FIELDS_COUNT}]"
+            )
+
+        try:
+            session_id: uuid.UUID = uuid.UUID(revealed_commitment_fields[0])
+        except ValueError as ve:
+            raise ValueError(
+                f"Invalid UUID session ID found in string encoding of {cls.__name__} -- caused by: {ve}"
+            ) from ve  # include UUID parsing exception cause
+
+        try:
+            party_id: int = int(revealed_commitment_fields[1])
+        except ValueError as ve:
+            raise ValueError(
+                f"Invalid party ID found in string encoding of {cls.__name__} -- caused by: {ve}"
+            ) from ve  # include integer parsing exception cause
+        else:
+            party_id: PartyId = cls._validate_party_id(party_id)
+
+        # Parse the embedded string-encoded NIZK proof of knowledge of discrete logarithm.
+        dlog_proof: NIZKDiscreteLogProof = NIZKDiscreteLogProof.from_string_encoding(
+            ':'.join(revealed_commitment_fields[2:7])  # fields #2-6 comprise the NIZK proof object
+        )
+
+        try:
+            commitment_key: bytearray = bytearray(base64.b64decode(revealed_commitment_fields[7], validate=True))
+        except binascii.Error as bae:
+            raise ValueError(
+                f"Invalid base64-encoded commitment verification key in string encoding of {cls.__name__} "
+                f"-- caused by: {bae}"
+            ) from bae  # include base64 decoding exception cause
+
+        # The commitment's cryptographic hash algorithm (i.e., used in its MAC or HMAC).
+        hash_algo: str = revealed_commitment_fields[8]
+
+        return cls(session_id, party_id, dlog_proof, commitment_key, hash_algo)
+
+    def encode_as_string(self) -> str:
+        """
+        Returns a string encoding of this revealed discrete log proof commitment, including the zero-knowledge proof
+        and associated parameters, proof verification key, commitment & commitment verification key, along with the
+        unique session ID, the party ID (i.e., #1: initiator or #2: responder) & the commitment's cryptographic hash
+        algorithm (e.g., SHA-256).
+        The encoding uses base64 for binary values and is colon-delimited as follows:
+            `<session_id>:<party_id>:<dlog_ref_point_base64>:<dlog_base_base64>:<proof_signature_base64>
+                :<proof_verification_key_base64>:<commitment_verification_key_base64>:<hash_algorithm>`
+        :return: a string encoding of this revealed discrete log proof commitment, using base64-encoding for binary
+                 values & a colon field delimiter.
+        """
+        encoded_proof: str = self.committed_dlog_proof.encode_as_string()
+        commitment_verification_key: str = base64.b64encode(self.commitment_verification_key).decode('utf-8')
+
+        return f"{self.session_id!s}:{self.party_id}:{encoded_proof}:{commitment_verification_key}:{self.hash_algo}"
+
+    def verify(self, keyed_hash_commitment: KeyedHashCommitment) -> bool:
+        return RevealedKeyedHashCommitment(
+            self.committed_dlog_proof.encode_for_commitment(),
+            self.commitment_verification_key,
+            self.hash_algo
+        ).verify(keyed_hash_commitment.commitment)
+
+    @classmethod
+    def _validate_party_id(cls, party_id: int) -> PartyId:
+        match party_id:
+            case 1: return 1
+            case 2: return 2
+            case invalid:
+                raise ValueError(
+                    f"Invalid party ID provided when constructing a {cls.__name__}: {invalid}"
+                )
+
+
+class DiscreteLogProofCommitmentUtils:
+    curve_config: WeierstrassEllipticCurveConfig
+    dlog_prover: NIZKDiscreteLogProver
+    dlog_verifier: NIZKDiscreteLogVerifier
+    commitment_utils: KeyedHashCommitmentUtils
+
+    def __init__(
+            self,
+            curve_config: WeierstrassEllipticCurveConfig,
+            commitment_hash_algorithm: str = KeyedHashCommitmentUtils.DEFAULT_HASH_ALGORITHM
+    ):
+        self.curve_config = curve_config
+        self.dlog_prover = NIZKDiscreteLogProver(self.curve_config)
+        self.dlog_verifier = NIZKDiscreteLogVerifier(self.curve_config)
+        self.commitment_utils = KeyedHashCommitmentUtils(commitment_hash_algorithm)
+
+    @property
+    def hash_algorithm(self) -> str:
+        return self.commitment_utils.hash_algo
+
+    def commit_prove(
+            self,
+            party_id: Literal[1, 2],
+            dlog_parameters: NIZKDiscreteLogParameters,
+            discrete_log: int
+    ) -> (SealedDiscreteLogProofCommitment, NIZKDiscreteLogProof, bytearray):
+        dlog_proof: NIZKDiscreteLogProof = self.dlog_prover.calc_proof(
+            discrete_log=discrete_log,
+            dlog_reference_point=dlog_parameters.dlog_ref_point,
+            discrete_log_base=dlog_parameters.dlog_base
+        )
+
+        sealed_commitment: SealedDiscreteLogProofCommitment
+        commitment_verification_key: bytearray
+        sealed_commitment, commitment_verification_key = SealedDiscreteLogProofCommitment.for_dlog_proof(
+            party_id,
+            dlog_proof,
+            self.hash_algorithm
+        )
+
+        return sealed_commitment, dlog_proof, commitment_verification_key


### PR DESCRIPTION
*NIZK Proof of Knowledge (PoK) of Discrete Log:*

- Added support for generating & verifying noninteractive zero-knowledge
(NIZK) proofs of knowledge (PoKs) of discrete logarithms over elliptic
curves, based on a Fiat-Shamir transformed interactive zero-knowledge
proof protocol, that's fashioned after the Schnorr identification/
authentication protocol.

*NIZK Discrete Log Proof Commitments:*

- Added support for generating & verifying NIZK PoKs of discrete
logarithms, combined with a cryptographic commitment to the associated
public parameters (namely the ECC point & associated base point/
generator for which the discrete log is being proven).
  - Specification of a unique session ID and party ID are supported,
  making it easier to incorporate this commit-prove functionality into a
  multi-party interactive protocol (e.g., for ensuring each party
  executes the protocol correctly).

*Update README re: new noninteractive ZKPs package:*

- Updated the README to add an entry under the Functional Existing
Modules section, re: the newly added support for noninteractive zero-
knowledge (NIZK) proofs of knowledge (PoKs) of discrete logarithms, in
the new `scriptless_zkp.ecc.zkp` package.

GI-7