### PR TITLE
qubits4all/GI-11: Fix NIZK equal d-logs proof parameter-set parser

### DIFF
--- a/src/python/scriptless_zkp/ecc/ecc_utils.py
+++ b/src/python/scriptless_zkp/ecc/ecc_utils.py
@@ -46,7 +46,7 @@ def generate_random_nonce_pair(
         curve_config: WeierstrassEllipticCurveConfig,
         ecc_base_point: Optional[ECC.EccPoint] = None,
         exclude_one: bool = False
-) -> (int, ECC.EccPoint):
+) -> tuple[int, ECC.EccPoint]:
     """
     Generates a random private nonce scalar (big integer) and an associated nonce elliptic curve (EC) point, constructed
     using the provided EC base point (as `nonce_point := nonce * base_point`), defaulting to the configured elliptic

--- a/src/python/scriptless_zkp/ecc/exceptions.py
+++ b/src/python/scriptless_zkp/ecc/exceptions.py
@@ -49,7 +49,7 @@ class InvalidECCPointException(Exception):
     def __repr__(self) -> str:
         return f"{type(self).__name__}: {self.msg}"
 
-    def invalid_coordinates(self) -> (int, int):
+    def invalid_coordinates(self) -> tuple[int, int]:
         return self.point_x, self.point_y
 
 

--- a/src/python/scriptless_zkp/ecc/generators.py
+++ b/src/python/scriptless_zkp/ecc/generators.py
@@ -33,7 +33,7 @@ from scriptless_zkp.number_theory import is_quadratic_residue, mod_sqrt
 
 class ECCGeneratorDerivationContext:
     curve_config: WeierstrassEllipticCurveConfig
-    domain_separator: str
+    domain_separator: str | None
 
     MIN_CANDIDATE_MAX_TWEAKS: int = 2
     DEFAULT_CANDIDATE_MAX_TWEAKS: int = 8  # Note: Must be a power of 2.
@@ -150,9 +150,9 @@ class ECCGeneratorDerivationContext:
         nums_generator: ECC.EccPoint | None = self._hunt_and_peck_for_generator(x_coord_candidate, max_tweaks)
         if nums_generator is None:
             if randomize_nonce:
-                suggestion_msg: str = "Try increasing `max_tweaks`."
+                suggestion_msg = "Try increasing `max_tweaks`."
             else:
-                suggestion_msg: str = "Try increasing `max_tweaks` or using a different nonce."
+                suggestion_msg = "Try increasing `max_tweaks` or using a different nonce."
 
             raise ValueError(
                 f"Failed to generate a valid generator point for nonce: {nonce} -- {suggestion_msg}"
@@ -172,7 +172,7 @@ class ECCGeneratorDerivationContext:
             if i >= 0 and i != x_coord_least_sig_bits:
                 # Munge x-coordinate candidate by replacing the last n least-significant bits with the bits of i.
                 mask: int = self._generate_x_coordinate_mask(max_tweaks)
-                x_coord: int = x_coordinate_candidate & mask | i
+                x_coord = x_coordinate_candidate & mask | i
 
             y_squared: int | None = self._check_x_coordinate_is_on_curve(x_coord)
             if y_squared is not None:

--- a/src/python/scriptless_zkp/ecc/signatures/schnorr.py
+++ b/src/python/scriptless_zkp/ecc/signatures/schnorr.py
@@ -130,13 +130,14 @@ class SchnorrKeyPair:
                  private key, which has been decrypted using the provided passphrase.
         """
         if encryption_passphrase is str:
+            # Explicitly encode string passphrase as UTF-8 (i.e., as opposed to relying on library to handle encoding).
             passphrase: bytes = encryption_passphrase.encode(encoding='utf-8')
         else:
             passphrase: Optional[bytes] = encryption_passphrase
 
         ecc_key_pair: ECC.EccKey = ECC.import_key(
             encoded=encoded_ecc_private_key,
-            passphrase=passphrase  # Allowed types: bytes | str | None
+            passphrase=passphrase  # Note: Allowed types: bytes | str | None
         )
         return SchnorrKeyPair(context, ecc_key_pair)
 

--- a/src/python/scriptless_zkp/ecc/zkp/nizk_dlog_proof.py
+++ b/src/python/scriptless_zkp/ecc/zkp/nizk_dlog_proof.py
@@ -190,19 +190,19 @@ class NIZKDiscreteLogParameters:
 Efficient type for an NIZK proof of knowledge of discrete log's signature that auto-casts to an `int`, but not from
 an `int`, providing type safety in function & method calls.
 """
-DiscreteLogProofSignature = NewType('NIZKDiscreteLogProofSignature', int)
+NIZKDiscreteLogProofSignature = NewType('NIZKDiscreteLogProofSignature', int)
 
 
 class NIZKDiscreteLogProof:
     discrete_log_params: NIZKDiscreteLogParameters
     ephemeral_public_key: ECC.EccKey
-    proof_signature: DiscreteLogProofSignature
+    proof_signature: NIZKDiscreteLogProofSignature
 
     def __init__(
             self,
             discrete_log_params: NIZKDiscreteLogParameters,
             ephemeral_public_key: ECC.EccKey,
-            proof_signature: DiscreteLogProofSignature
+            proof_signature: NIZKDiscreteLogProofSignature
     ):
         self.curve_config = discrete_log_params.curve_config
         self.discrete_log_params = discrete_log_params
@@ -240,7 +240,7 @@ class NIZKDiscreteLogProof:
             ) from ve
 
         try:
-            proof_signature: DiscreteLogProofSignature = DiscreteLogProofSignature(number.bytes_to_long(
+            proof_signature: NIZKDiscreteLogProofSignature = NIZKDiscreteLogProofSignature(number.bytes_to_long(
                 base64.b64decode(dlog_proof_fields[3], validate=True)
             ))
         except binascii.Error as bae:
@@ -382,7 +382,7 @@ class NIZKDiscreteLogProver:
         return NIZKDiscreteLogProof(
             NIZKDiscreteLogParameters(self.curve_config, dlog_ref_point, discrete_log_base),
             ephemeral_public_key,
-            DiscreteLogProofSignature(proof_signature)
+            NIZKDiscreteLogProofSignature(proof_signature)
         )
 
     def _generate_ephemeral_keypair(self) -> ECC.EccKey:

--- a/src/python/scriptless_zkp/ecc/zkp/nizk_equal_dlogs_proof.py
+++ b/src/python/scriptless_zkp/ecc/zkp/nizk_equal_dlogs_proof.py
@@ -193,6 +193,9 @@ class NIZKDiscreteLogParameterSet:
         self.hash_algo = hash_algorithm
         self.dlog_base_and_ref_points = dlog_base_and_ref_points
 
+    # TODO: Update this string encoding parser to parse the hash algorithm used for the associated proof, from a
+    #   revised string encoding including the hash algorithm.
+    #   (Note: This field is already present in the NIZK proof's encoding.)
     @classmethod
     def from_string_encoding(cls, encoded_parameter_set: str) -> NIZKDiscreteLogParameterSet:
         """
@@ -251,23 +254,37 @@ class NIZKDiscreteLogParameterSet:
                 dlog_base_bytes: bytes = base64.b64decode(dlog_base_field)
                 ref_pt_bytes: bytes = base64.b64decode(ref_pt_field)
 
-                dlog_base = ECC.import_key(dlog_base_bytes, curve_name=curve_name)
-                ref_pt = ECC.import_key(ref_pt_bytes, curve_name=curve_name)
+                # Decode the ECC discrete log's assoc. base point from its SEC1 binary encoding.
+                dlog_base: ECC.EccPoint = ECC.import_key(
+                    dlog_base_bytes,
+                    curve_name=curve_name
+                ).pointQ
+                # Decode the ECC discrete log's assoc. "reference" point from its SEC1 binary encoding (i.e., where this
+                # "reference" point equals the base point multiplied by the discrete log).
+                ref_pt: ECC.EccPoint = ECC.import_key(
+                    ref_pt_bytes,
+                    curve_name=curve_name
+                ).pointQ
             except (ValueError, TypeError, binascii.Error) as ex:
                 raise ValueError(
                     f"Invalid NIZK equal discrete logs proof encoding -- failed to decode the set of discrete log"
                     f" product/base point pairs, due to exception: {ex}"
                 ) from ex
             else:
-                dlog_base_and_ref_points.append(ECCDiscreteLogBaseAndProduct((dlog_base, ref_pt)))
+                dlog_base_and_ref_points.append(
+                    ECCDiscreteLogBaseAndProduct(
+                        (dlog_base, ref_pt)
+                    )
+                )
 
-        # TODO: Parse the hash algorithm used for the proof, since this should be specified in the parameter-set's
-        #   constructor. (Note: This field is already present in the NIZK proof's encoding.)
         return NIZKDiscreteLogParameterSet(
             curve_config,
             dlog_base_and_ref_points
         )
 
+    # TODO: Modify the string encoding produced by this method to include the hash algorithm to be used for the
+    #   associated zero-knowledge proof. Consider including an encoding version field in the revised encoding.
+    #   (Note: This field is already present in the NIZK proof's encoding.)
     def encode_as_string(self) -> str:
         # noinspection PyCompatibility
         """

--- a/src/python/scriptless_zkp/he/paillier.py
+++ b/src/python/scriptless_zkp/he/paillier.py
@@ -252,7 +252,7 @@ class PaillierPrivateKey:
             hmac_hash_algorithm: str = DEFAULT_HMAC_HASH_ALGORITHM,  # default: HMAC-SHA3-256
             salt_size_bytes: int = DEFAULT_PKCS8_HMAC_SALT_BYTES,    # default: 32 bytes (256 bits)
             aes_key_size_bytes: int = DEFAULT_PKCS8_AES_KEY_BYTES    # default: AES-128 key size (16 bytes)
-    ) -> (bytes, dict[str, int]):
+    ) -> tuple[bytes, dict[str, int]]:
         """
         Encrypts the base64-encoded Paillier private key using PKCS#8 password-based key-wrap encryption, using PBKDF2
         for password-based symmetric (AES) key derivation and AES-CBC for encryption of the provided encoded private
@@ -417,7 +417,7 @@ class PaillierPrivateKey:
         return private_key
 
     @staticmethod
-    def _decode_pkcs8_encrypted_private_key(encrypted_private_key: str) -> (bytes, dict[str, int]):
+    def _decode_pkcs8_encrypted_private_key(encrypted_private_key: str) -> tuple[bytes, dict[str, int]]:
         """
         Decodes a PKCS#8 encrypted Paillier private key, including the PBKDF2 parameters used for symmetric key
         derivation, from a string-encoded representation.
@@ -491,9 +491,9 @@ class PaillierPrivateKey:
             ) from vex
 
         # Extract the base64-encoded ASN.1 DER byte string of the encrypted private key.
-        encrypted_private_key: bytes = base64.b64decode(fields[ENCRYPTED_KEY_POS])
+        encrypted_private_key_der: bytes = base64.b64decode(fields[ENCRYPTED_KEY_POS])
 
-        return encrypted_private_key, pbkdf2_params
+        return encrypted_private_key_der, pbkdf2_params
 
     def _encode_to_base64(self) -> str:
         """
@@ -814,7 +814,7 @@ class PaillierKeyPair:
         return cls(pub_key, priv_key)
 
     @staticmethod
-    def _generate_primes(size_bits: int) -> (int, int, int):
+    def _generate_primes(size_bits: int) -> tuple[int, int, int]:
         """
         Generates two "strong" primes (i.e., a prime `p` such that `p - 1` and `p + 1` both have at least one large
         prime factor), using the specified bit-size for each prime. Using "strong" primes thereby provides protection


### PR DESCRIPTION
### q4a/GI-11-fix-nizk-equal-dlogs-encoding

*Fix NIZK Equal d-logs proof param.-set encoding:*

- Corrected the string-encoding parser for the NIZK Equal Discrete Logs
Proof module's parameter-set, which had missed two necessary
conversions.

- Added TODO comments to the Equal Discrete Logs NIZK Proof module, re:
improving the `NIZKDiscreteLogParameterSet`'s string encoding to include
the assoc. ZK proof's chosen hash algorithm.

GI-11

*Fix several issues found with mypy:*

- Fixed several type annotation issues, and a few other issues, found
with the mypy tool.