### PR TITLE
bugfix/GI-7: Fix ZKP and HMAC Tuple return-types & PartyId type alias

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ Repository = "https://github.com/qubits4all/scriptless-zkp.git"
 Issues = "https://github.com/qubits4all/scriptless-zkp/issues"
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = "^3.12"
 attrs = "~23.2.0"
 pycryptodomex = "~3.20.0"
 libnum = "~1.7.1"

--- a/src/python/scriptless_zkp/__init__.py
+++ b/src/python/scriptless_zkp/__init__.py
@@ -16,7 +16,7 @@
 
 from typing import Literal
 
-PartyId = Literal[1, 2]
+type PartyId = Literal[1, 2]
 """Alias to the party ID literal type, which must be either 1 (initiator) or 2 (responder)."""
 
 STRING_ENCODING_FIELD_DELIMITER: str = ':'

--- a/src/python/scriptless_zkp/commitments/hmac_commitments.py
+++ b/src/python/scriptless_zkp/commitments/hmac_commitments.py
@@ -49,7 +49,7 @@ class KeyedHashCommitmentUtils:
     def commit(
             self,
             secret_message: Union[bytes, bytearray]
-    ) -> (KeyedHashCommitment, RevealedKeyedHashCommitment):
+    ) -> tuple[KeyedHashCommitment, RevealedKeyedHashCommitment]:
         """
         Produces a keyed hash-based commitment for the given secret message, using a random ephemeral key.
         :param secret_message: secret message to which to commit.
@@ -100,7 +100,7 @@ class KeyedHashCommitmentUtils:
 
         return hmac.compare_digest(commitment, expected_commitment)
 
-    def _generate_keyed_hash(self, secret_message: Union[bytes, bytearray]) -> (BinaryCommitment, bytearray):
+    def _generate_keyed_hash(self, secret_message: Union[bytes, bytearray]) -> tuple[BinaryCommitment, bytearray]:
         """
         <p>
         Generates a random ephemeral key equal to the configured hash algorithm's digest size, and produces a

--- a/src/python/scriptless_zkp/ecc/zkp/nizk_dlog_proof.py
+++ b/src/python/scriptless_zkp/ecc/zkp/nizk_dlog_proof.py
@@ -297,7 +297,7 @@ class NIZKDiscreteLogProof:
         """
         Binary encodes & concatenates this NIZK proof of knowledge of discrete logarithm, along with its associated
         discrete log parameters, and proof verification key, as follows:
-            `<dlog_ref_point><dlog_base><proof_signature><proof_verification_key>`
+            `<dlog_ref_point><dlog_base><proof_verification_key><proof_signature>`
         Elliptic curve points are 'SEC1'-encoded.
         :return: this NIZK proof of knowledge of discrete logarithm, along with its associated discrete log parameters,
                  and proof verification key, binary encoded & concatenated, where 'SEC1' encoding is used for elliptic

--- a/src/python/scriptless_zkp/ecc/zkp/nizk_dlog_proof_commitments.py
+++ b/src/python/scriptless_zkp/ecc/zkp/nizk_dlog_proof_commitments.py
@@ -43,7 +43,7 @@ class SealedDiscreteLogProofCommitment:
             party_id: PartyId,
             dlog_proof: NIZKDiscreteLogProof,
             hash_algorithm: str = KeyedHashCommitmentUtils.DEFAULT_HASH_ALGORITHM
-    ) -> (SealedDiscreteLogProofCommitment, bytearray):
+    ) -> tuple[SealedDiscreteLogProofCommitment, bytearray]:
         """
         Constructs a sealed commitment to the provided discrete logarithm proof and associated discrete log parameters,
         including the discrete log reference point, discrete log base, proof signature & proof verification key.
@@ -146,7 +146,7 @@ class SealedDiscreteLogProofCommitment:
 
 class RevealedDiscreteLogProofCommitment:
     session_id: uuid.UUID    # globally-unique ID for a protocol session
-    party_id: Literal[1, 2]  # prover/committer party's ID (i.e., either #1: initiator or #2: responder)
+    party_id: PartyId        # prover/committer party's ID (i.e., either #1: initiator or #2: responder)
     committed_dlog_proof: NIZKDiscreteLogProof
     commitment_verification_key: bytearray
     hash_algo: str
@@ -159,7 +159,7 @@ class RevealedDiscreteLogProofCommitment:
             commitment_verification_key: bytearray,
             commitment_hash_algorithm: str
     ):
-        self.party_id = type(self)._validate_party_id(party_id)
+        self.party_id: PartyId = self._validate_party_id(party_id)
         self.session_id = session_id
         self.committed_dlog_proof = discrete_log_proof
         self.commitment_verification_key = commitment_verification_key
@@ -292,7 +292,7 @@ class DiscreteLogProofCommitmentUtils:
             party_id: Literal[1, 2],
             dlog_parameters: NIZKDiscreteLogParameters,
             discrete_log: int
-    ) -> (SealedDiscreteLogProofCommitment, NIZKDiscreteLogProof, bytearray):
+    ) -> tuple[SealedDiscreteLogProofCommitment, NIZKDiscreteLogProof, bytearray]:
         dlog_proof: NIZKDiscreteLogProof = self.dlog_prover.calc_proof(
             discrete_log=discrete_log,
             dlog_reference_point=dlog_parameters.dlog_ref_point,


### PR DESCRIPTION
### bugfix/GI-7: Fix ZKP and HMAC Tuple return-types & PartyId type alias

*[zkp] Fix Tuple return-types & PartyId typing:*
- Fixed several Tuple return-types in the NIZK discrete log proof, NIZK d-log proof commitments & HMAC commitments modules.
- Corrected the PartyId type alias for the Literal[1, 2] type, used in the NIZK d-log proof commitments module.
- Fixed a doc-comment re: the binary encoding used in the NIZK d-log proofs module's `encode_for_commitment(...)` method.

GI-6, GI-7