### PR TITLE
bugfix/GI-16: Fix universal prime length hasher re: bounds check

### DIFF
--- a/src/python/scriptless_zkp/ecc/commitments/pedersen.py
+++ b/src/python/scriptless_zkp/ecc/commitments/pedersen.py
@@ -53,9 +53,10 @@ class PedersenCommitmentContext:
         :param nonce: a nonce to use when deriving the NUMS generator.
         :return: a new Pedersen commitment context for the provided elliptic curve configuration, using a derived NUMS
                  generator point.
-        :raises ValueError: a NUMS point could not be derived for the provided nonce, given the NUMS point generator's
-                            default max. tweak count. (Note: This is a rare occurrence, and the nonce can be changed to
-                            try again.)
+        :raises ValueError: if a NUMS generator point cannot be derived for the provided (or default) nonce, using the
+                default maximum number of tweaks (``ECCGeneratorDerivationContext.DEFAULT_CANDIDATE_MAX_TWEAKS``).
+                (Note: This is a rare occurrence, and the nonce can be changed to try again.)
+        :see: ``ECCGeneratorDerivationContext.derive_generator_for_nonce(nonce)``
         """
         generator_context: ECCGeneratorDerivationContext = ECCGeneratorDerivationContext(
             curve_config,

--- a/src/python/scriptless_zkp/hashing.py
+++ b/src/python/scriptless_zkp/hashing.py
@@ -53,10 +53,12 @@ class ReducedRangeHasher(ABC):
     def digest(self) -> bytes:
         pass
 
+    # noinspection SpellCheckingInspection
     @abstractmethod
     def intdigest(self) -> int:
         pass
 
+    # noinspection SpellCheckingInspection
     @abstractmethod
     def hexdigest(self) -> str:
         pass
@@ -190,7 +192,7 @@ class UniversalPrimeLengthHasher(ReducedRangeHasher):
         field_order_bit_length: int = target_field_order.bit_length()
 
         if larger_prime_p is not None:
-            if larger_prime_p.bit_length() < math.ceil(target_field_order * 1.5):
+            if larger_prime_p.bit_length() < math.ceil(field_order_bit_length * 1.5):
                 raise ValueError(
                     f"Provided prime `p` must be at least 1.5 times the bit-length of the target field order: "
                     f"{field_order_bit_length} bits."


### PR DESCRIPTION
### bugfix/GI-16: Fix universal prime length hasher re: bounds check

*Fix UniversalPrimeLengthHasher bounds check:*

- Corrected a bounds check on the `larger_prime_p` parameter of the
`UniversalPrimeLengthHasher` class's `for_field_order(...)` factory
method, which had erroneously compared the bit-length of this parameter
with the `field_order` parameter times 1.5 (i.e., instead of 1.5 times
the latter's bit-length).

*Correct doc-comments re: NUMS point gen. for Pedersen:*

- Corrected the doc-comments for the `PedersenCommitmentContext`'s
`for_curve(...)` factory method, which generates a pseudorandom ECC NUMS
point for use in Pedersen commitments generation, based on a provided
(or defaulted) nonce value, to indicate that this factory may raise a
`ValueError` if the underlying ECC point generation is unsuccessful in
finding a valid point on the configured elliptic curve for the given
nonce (i.e., within the configured number of tweaks to the generated
x-coordinate).

GI-16